### PR TITLE
Add felice photo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @pyladies/tech-and-infra-admins and @pyladies/pyladies-global-admin will be requested for
+# review when someone opens a pull request.
+*       @pyladies/nyc

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
                     </div>
                     <div class="bio-container">
                         <div class="organizer-container">
-                            <img src="./images/bios/yisselda_photo.jpeg" class="organizer" />
+                            <img src="./images/bios/felice.jpg" class="organizer" />
                         </div>
                         <div class="bio">
                             <p class="name">Felice Ho</p>


### PR DESCRIPTION
# Overview

This PR includes:

- In the changes @reshamas made which have been copied over [here](https://github.com/pyladies/pyladies/commit/91bb0c0d24fa5d491a306633849b3a3d0475a311),  organizer Felice's photo was missing. It's now a dded in!
- Adds `CODEOWNERS` to tag @pyladies/nyc whenever open PRs

Here's the [preview](https://deploy-preview-1--ecstatic-perlman-d81b7c.netlify.app/) @reshamas!